### PR TITLE
WIP: Add new metrics button

### DIFF
--- a/ifbcat_api/admin.py
+++ b/ifbcat_api/admin.py
@@ -453,6 +453,7 @@ class TrainingCourseMetricsAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmi
         'event__description',
     )
     autocomplete_fields = ('event',)
+    list_filter = ('event',)
 
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)

--- a/ifbcat_api/templates/jazzmin/admin__content__pre_dashboard_card.html
+++ b/ifbcat_api/templates/jazzmin/admin__content__pre_dashboard_card.html
@@ -26,9 +26,11 @@
             {% for instance in model.instances %}
                 <li>
                     <a href="{{model.admin_url}}{{instance.pk}}">{{instance}}</a>
-                    {% if model.action_url %}
-                    <a role="button" href="{% url model.action_url instance.pk %}" class="btn btn-xs btn-outline-success float-right">{{model.action_text}}</a>
-                    {% endif %}
+                    <div class="btn-group float-right" role="group" aria-label="Basic example">
+                    {% for action in model.actions %}
+                    <a role="button" href="{% url action.url instance.pk %}" class="btn btn-xs btn-outline-success">{{action.text}}</a>
+                    {% endfor %}
+                    </div>
                 </li>
             {%endfor%}
             </ul>

--- a/ifbcat_api/templatetags/ifbcat.py
+++ b/ifbcat_api/templatetags/ifbcat.py
@@ -54,6 +54,10 @@ def get_editable_instance(context: Context) -> List[Dict]:
                 editable.append(model)
         elif model['object_name'] == 'Event':
             if model['perms']['change']:
+                model['actions'] = [
+                    dict(url='add_metrics', text='Add'),
+                    dict(url='manage_metrics', text='Manage metrics'),
+                ]
                 model['instances'] = models.Event.objects.filter(
                     Q(contactId=user)
                     | Q(trainers__trainerId=user)

--- a/ifbcat_api/urls.py
+++ b/ifbcat_api/urls.py
@@ -59,4 +59,14 @@ urlpatterns = [
         views.new_training_course,
         name='new_training_course',
     ),
+    path(
+        'event/<int:event_pk>/metrics/',
+        views.manage_metrics,
+        name='manage_metrics',
+    ),
+    path(
+        'event/<int:event_pk>/new-metrics/',
+        views.add_metrics,
+        name='add_metrics',
+    ),
 ]

--- a/ifbcat_api/views.py
+++ b/ifbcat_api/views.py
@@ -14,6 +14,8 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.core.cache import cache
 from django.http import HttpResponseRedirect, HttpResponseForbidden
 from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_cookie
@@ -815,3 +817,30 @@ def new_training_course(request, training_pk):
         return HttpResponseForbidden('You cannot create new Event.')
     course, redirect_url = TrainingAdmin.create_new_course_and_get_admin_url(request=request, training=training)
     return HttpResponseRedirect(redirect_url)
+
+
+@staff_member_required
+def manage_metrics(request, event_pk):
+    return HttpResponseRedirect(
+        '%s?event__id__exact=%i'
+        % (
+            reverse('admin:ifbcat_api_trainingcoursemetrics_changelist'),
+            event_pk,
+        )
+    )
+
+
+@staff_member_required
+def add_metrics(request, event_pk):
+    t = models.TrainingCourseMetrics.objects.create(
+        event=get_object_or_404(models.Event, pk=event_pk),
+        dateStart=timezone.now().date(),
+        dateEnd=timezone.now().date(),
+    )
+    return HttpResponseRedirect(
+        '%s?_changelist_filters=event__id__exact:%i'
+        % (
+            reverse('admin:ifbcat_api_trainingcoursemetrics_change', args=[t.id]),
+            event_pk,
+        )
+    )


### PR DESCRIPTION
Closes #160 

J'ai juste une question @thomasrosnet, pour l'instant on peut ajouter une metrics sur tout les événements, pas juste les training. Est-ce que les boutons que je viens d'ajouter qui permette d'ajouter rapidement une métrique devrait être limité aux sessions de training, ou cela pourrait aussi servir au reste ? Je pense que cela pourrais servir mais je voulais ton avis.