### PR TITLE
Formatting admin, one parent class per line

### DIFF
--- a/ifbcat_api/admin.py
+++ b/ifbcat_api/admin.py
@@ -122,7 +122,11 @@ class ViewInApiModelByNameAdmin(ViewInApiModelAdmin):
 
 
 @admin.register(models.UserProfile)
-class UserProfileAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin, UserAdmin):
+class UserProfileAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+    UserAdmin,
+):
     # Enables search, filtering and widgets in Django admin interface.
     ordering = ("email",)
     list_display = (
@@ -573,17 +577,26 @@ class TrainingAdmin(
 
 
 @admin.register(models.Keyword)
-class KeywordAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class KeywordAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = ['keyword']
 
 
 @admin.register(models.EventPrerequisite)
-class EventPrerequisiteAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class EventPrerequisiteAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = ['prerequisite']
 
 
 @admin.register(models.Topic)
-class TopicAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class TopicAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = ['uri', 'label', 'description', 'synonyms']
     list_display = (
         'label',
@@ -602,12 +615,18 @@ class TopicAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
 
 
 @admin.register(models.EventCost)
-class EventCostAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class EventCostAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = ['cost']
 
 
 @admin.register(models.Trainer)
-class TrainerAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class TrainerAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = (
         'trainerName',
         'trainerEmail',
@@ -619,7 +638,10 @@ class TrainerAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
 
 
 @admin.register(models.TrainingCourseMetrics)
-class TrainingCourseMetricsAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class TrainingCourseMetricsAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = (
         'dateStart',
         'dateEnd',
@@ -636,7 +658,10 @@ class TrainingCourseMetricsAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmi
 
 
 @admin.register(models.EventSponsor)
-class EventSponsorAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class EventSponsorAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = (
         'name',
         'organisationId__name',
@@ -645,7 +670,10 @@ class EventSponsorAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
 
 
 @admin.register(models.Certification)
-class CertificationAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class CertificationAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = (
         'name',
         'description',
@@ -653,7 +681,10 @@ class CertificationAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
 
 
 @admin.register(models.Community)
-class CommunityAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class CommunityAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = (
         'name',
         'description',
@@ -664,7 +695,10 @@ class CommunityAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
 
 
 @admin.register(models.ElixirPlatform)
-class ElixirPlatformAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class ElixirPlatformAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = (
         'name',
         'description',
@@ -679,7 +713,10 @@ class ElixirPlatformAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
 
 
 @admin.register(models.Organisation)
-class OrganisationAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class OrganisationAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = (
         'name',
         'description',
@@ -693,12 +730,18 @@ class OrganisationAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
 
 
 @admin.register(models.Field)
-class FieldAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class FieldAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = ('field',)
 
 
 @admin.register(models.Doi)
-class DoiAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class DoiAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = ('doi',)
     list_display = (
         'doi',
@@ -724,7 +767,10 @@ class DoiAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
 
 
 @admin.register(models.Project)
-class ProjectAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class ProjectAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = (
         'name',
         'homepage',
@@ -750,17 +796,26 @@ class ProjectAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
 
 
 @admin.register(models.AudienceRole)
-class AudienceRoleAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class AudienceRoleAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = ['audienceRole']
 
 
 @admin.register(models.AudienceType)
-class AudienceTypeAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class AudienceTypeAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = ['audienceType']
 
 
 @admin.register(models.TrainingMaterial)
-class TrainingMaterialAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class TrainingMaterialAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = (
         'doi__doi',
         'fileName',
@@ -784,7 +839,10 @@ class TrainingMaterialAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
 
 
 @admin.register(models.ComputingFacility)
-class ComputingFacilityAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class ComputingFacilityAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = (
         'homepage',
         'providedBy__name',
@@ -801,7 +859,10 @@ class ComputingFacilityAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
 
 
 @admin.register(models.Team)
-class TeamAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class TeamAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     ordering = (Upper(Unaccent("name")),)
     search_fields = (
         'name',
@@ -909,7 +970,10 @@ class TeamAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
 
 
 @admin.register(models.Service)
-class ServiceAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class ServiceAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = (
         'name',
         'description',
@@ -929,7 +993,10 @@ class ServiceAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
 
 
 @admin.register(models.ServiceSubmission)
-class ServiceSubmissionAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class ServiceSubmissionAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = (
         'service__name',
         'authors__firstname',
@@ -949,7 +1016,10 @@ class ServiceSubmissionAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
 
 
 @admin.register(models.Tool)
-class ToolAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
+class ToolAdmin(
+    PermissionInClassModelAdmin,
+    ViewInApiModelAdmin,
+):
     search_fields = (
         'name',
         'biotoolsID',
@@ -1055,7 +1125,10 @@ admin.site.unregister(Group)
 
 # Create a new Group admin.
 @admin.register(Group)
-class GroupAdmin(PermissionInClassModelAdmin, GroupAdmin):
+class GroupAdmin(
+    PermissionInClassModelAdmin,
+    GroupAdmin,
+):
     # Use our custom form.
     form = GroupAdminForm
     # Filter permissions horizontal as well.
@@ -1110,7 +1183,10 @@ admin.site.unregister(Token)
 
 
 @admin.register(Token)
-class TokenAdmin(PermissionInClassModelAdmin, admin.ModelAdmin):
+class TokenAdmin(
+    PermissionInClassModelAdmin,
+    admin.ModelAdmin,
+):
     list_display = ('key', 'user', 'created')
     fields = ('user',)
     ordering = ('-created',)
@@ -1135,7 +1211,9 @@ class TokenAdmin(PermissionInClassModelAdmin, admin.ModelAdmin):
 from django.apps import apps
 
 
-class DefaultPermissionInClassModelAdmin(PermissionInClassModelAdmin):
+class DefaultPermissionInClassModelAdmin(
+    PermissionInClassModelAdmin,
+):
     pass
 
 

--- a/ifbcat_api/admin.py
+++ b/ifbcat_api/admin.py
@@ -113,6 +113,15 @@ class ViewInApiModelAdmin(admin.ModelAdmin, DynamicArrayMixin):
     view_in_api_in_list.short_description = format_html('<center>View in API<center>')
 
 
+class AllFieldInAutocompleteModelAdmin(admin.ModelAdmin):
+    class Meta:
+        abstract = True
+
+    @property
+    def autocomplete_fields(self):
+        return list(set([f.name for f in self.model._meta.local_many_to_many]) - set(self.filter_horizontal))
+
+
 class ViewInApiModelByNameAdmin(ViewInApiModelAdmin):
     slug_name = "name"
 
@@ -124,6 +133,7 @@ class ViewInApiModelByNameAdmin(ViewInApiModelAdmin):
 @admin.register(models.UserProfile)
 class UserProfileAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
     UserAdmin,
 ):
@@ -171,7 +181,6 @@ class UserProfileAdmin(
         "user_permissions",
         "groups",
     )
-    autocomplete_fields = ("expertise",)
     add_form = modelform_factory(models.UserProfile, fields=('email',))
 
     def can_manager_user(self, request, obj):
@@ -235,6 +244,7 @@ class UserProfileAdmin(
 class EventAdmin(
     ModelAdminFillingContactId,
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     """Enables search, filtering and widgets in Django admin interface."""
@@ -279,15 +289,6 @@ class EventAdmin(
     )
     #
     filter_horizontal = ()
-    autocomplete_fields = (
-        'costs',
-        'topics',
-        'keywords',
-        'prerequisites',
-        'elixirPlatforms',
-        'communities',
-        'sponsoredBy',
-    )
     fieldsets = (
         (
             'Event info',
@@ -417,6 +418,7 @@ class EventAdmin(
 class TrainingAdmin(
     ModelAdminFillingContactId,
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     list_display = (
@@ -455,10 +457,6 @@ class TrainingAdmin(
         'tess_publishing',
         # 'databases',
         # 'tools',
-    )
-    autocomplete_fields = (
-        'trainingMaterials',
-        'computingFacilities',
     )
     fieldsets = (
         (
@@ -579,6 +577,7 @@ class TrainingAdmin(
 @admin.register(models.Keyword)
 class KeywordAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = ['keyword']
@@ -587,6 +586,7 @@ class KeywordAdmin(
 @admin.register(models.EventPrerequisite)
 class EventPrerequisiteAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = ['prerequisite']
@@ -595,6 +595,7 @@ class EventPrerequisiteAdmin(
 @admin.register(models.Topic)
 class TopicAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = ['uri', 'label', 'description', 'synonyms']
@@ -617,6 +618,7 @@ class TopicAdmin(
 @admin.register(models.EventCost)
 class EventCostAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = ['cost']
@@ -625,6 +627,7 @@ class EventCostAdmin(
 @admin.register(models.Trainer)
 class TrainerAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = (
@@ -634,12 +637,12 @@ class TrainerAdmin(
         'trainerId__firstname',
         'trainerId__lastname',
     )
-    autocomplete_fields = ('trainerId',)
 
 
 @admin.register(models.TrainingCourseMetrics)
 class TrainingCourseMetricsAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = (
@@ -649,7 +652,6 @@ class TrainingCourseMetricsAdmin(
         'event__shortName',
         'event__description',
     )
-    autocomplete_fields = ('event',)
 
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)
@@ -660,18 +662,19 @@ class TrainingCourseMetricsAdmin(
 @admin.register(models.EventSponsor)
 class EventSponsorAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = (
         'name',
         'organisationId__name',
     )
-    autocomplete_fields = ('organisationId',)
 
 
 @admin.register(models.Certification)
 class CertificationAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = (
@@ -683,6 +686,7 @@ class CertificationAdmin(
 @admin.register(models.Community)
 class CommunityAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = (
@@ -691,12 +695,12 @@ class CommunityAdmin(
         'homepage',
         'organisations__name',
     )
-    autocomplete_fields = ('organisations',)
 
 
 @admin.register(models.ElixirPlatform)
 class ElixirPlatformAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = (
@@ -715,6 +719,7 @@ class ElixirPlatformAdmin(
 @admin.register(models.Organisation)
 class OrganisationAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = (
@@ -726,12 +731,12 @@ class OrganisationAdmin(
         'city',
     )
     list_filter = ('fields',)
-    autocomplete_fields = ('fields',)
 
 
 @admin.register(models.Field)
 class FieldAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = ('field',)
@@ -740,6 +745,7 @@ class FieldAdmin(
 @admin.register(models.Doi)
 class DoiAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = ('doi',)
@@ -769,6 +775,7 @@ class DoiAdmin(
 @admin.register(models.Project)
 class ProjectAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = (
@@ -784,20 +791,12 @@ class ProjectAdmin(
         'uses__name',
     )
     list_filter = ('elixirPlatforms', 'communities', 'hostedBy', 'uses')
-    autocomplete_fields = (
-        'topics',
-        'elixirPlatforms',
-        'communities',
-        'team',
-        'hostedBy',
-        'fundedBy',
-        'uses',
-    )
 
 
 @admin.register(models.AudienceRole)
 class AudienceRoleAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = ['audienceRole']
@@ -806,6 +805,7 @@ class AudienceRoleAdmin(
 @admin.register(models.AudienceType)
 class AudienceTypeAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = ['audienceType']
@@ -814,6 +814,7 @@ class AudienceTypeAdmin(
 @admin.register(models.TrainingMaterial)
 class TrainingMaterialAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = (
@@ -828,19 +829,11 @@ class TrainingMaterialAdmin(
         'license',
     )
 
-    autocomplete_fields = (
-        'communities',
-        'elixirPlatforms',
-        'topics',
-        'keywords',
-        'audienceTypes',
-        'audienceRoles',
-    )
-
 
 @admin.register(models.ComputingFacility)
 class ComputingFacilityAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = (
@@ -852,15 +845,11 @@ class ComputingFacilityAdmin(
 
     list_filter = ('accessibility',)
 
-    autocomplete_fields = (
-        'providedBy',
-        'trainingMaterials',
-    )
-
 
 @admin.register(models.Team)
 class TeamAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     ordering = (Upper(Unaccent("name")),)
@@ -880,15 +869,6 @@ class TeamAdmin(
         'members__lastname',
         'maintainers__firstname',
         'maintainers__lastname',
-    )
-
-    autocomplete_fields = (
-        'leader',
-        'deputies',
-        'scientificLeaders',
-        'technicalLeaders',
-        'members',
-        'maintainers',
     )
     filter_horizontal = (
         'scientificLeaders',
@@ -910,68 +890,10 @@ class TeamAdmin(
     logo.short_description = format_html("<center>" + ugettext("Image") + "<center>")
 
 
-# @admin.register(models.BioinformaticsTeam)
-# class BioinformaticsTeamAdmin(PermissionInClassModelAdmin, ViewInApiModelAdmin):
-#     ordering = (Unaccent("name"),)
-#     search_fields = (
-#         'name',
-#         'description',
-#         'expertise__uri',
-#         'leader__firstname',
-#         'leader__lastname',
-#         'deputies__firstname',
-#         'deputies__lastname',
-#         'scientificLeaders__firstname',
-#         'scientificLeaders__lastname',
-#         'technicalLeaders__firstname',
-#         'technicalLeaders__lastname',
-#         'members__firstname',
-#         'members__lastname',
-#         'maintainers__firstname',
-#         'maintainers__lastname',
-#         'orgid',
-#         'unitId',
-#         'address',
-#         'fields__field',
-#         'keywords__keyword',
-#         'communities__name',
-#         'projects__name',
-#         'fundedBy__name',
-#         'publications__doi',
-#         'certifications__name',
-#     )
-#
-#     list_filter = ('fields',)
-#
-#     autocomplete_fields = (
-#         'fields',
-#         'platforms',
-#         'communities',
-#         'projects',
-#     )
-#     filter_horizontal = (
-#         'scientificLeaders',
-#         'technicalLeaders',
-#         'members',
-#         'maintainers',
-#         'deputies',
-#     )
-#     list_display = (
-#         'name',
-#         'logo',
-#     )
-#
-#     def logo(self, obj):
-#         if obj.logo_url:
-#             return format_html('<center style="margin: -8px;"><img height="32px" src="' + obj.logo_url + '"/><center>')
-#         return format_html('<center style="margin: -8px;">-<center>')
-#
-#     logo.short_description = format_html("<center>" + ugettext("Image") + "<center>")
-
-
 @admin.register(models.Service)
 class ServiceAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = (
@@ -984,17 +906,11 @@ class ServiceAdmin(
         'publications__doi',
     )
 
-    autocomplete_fields = (
-        'computingFacilities',
-        'trainings',
-        'trainingMaterials',
-        'teams',
-    )
-
 
 @admin.register(models.ServiceSubmission)
 class ServiceSubmissionAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = (
@@ -1012,12 +928,11 @@ class ServiceSubmissionAdmin(
         'sustainability',
     )
 
-    autocomplete_fields = ('service',)
-
 
 @admin.register(models.Tool)
 class ToolAdmin(
     PermissionInClassModelAdmin,
+    AllFieldInAutocompleteModelAdmin,
     ViewInApiModelAdmin,
 ):
     search_fields = (
@@ -1215,6 +1130,41 @@ class DefaultPermissionInClassModelAdmin(
     PermissionInClassModelAdmin,
 ):
     pass
+
+
+@admin.register(models.Collection)
+class CollectionAdmin(
+    PermissionInClassModelAdmin,
+):
+    search_fields = ('name',)
+
+
+@admin.register(models.OperatingSystem)
+class CollectionAdmin(
+    PermissionInClassModelAdmin,
+):
+    search_fields = ('name',)
+
+
+@admin.register(models.TypeRole)
+class CollectionAdmin(
+    PermissionInClassModelAdmin,
+):
+    search_fields = ('name',)
+
+
+@admin.register(models.ToolCredit)
+class CollectionAdmin(
+    PermissionInClassModelAdmin,
+):
+    search_fields = ('name',)
+
+
+@admin.register(models.ToolType)
+class CollectionAdmin(
+    PermissionInClassModelAdmin,
+):
+    search_fields = ('name',)
 
 
 models = apps.get_app_config('ifbcat_api').get_models()


### PR DESCRIPTION
Graphical bug hav been spotted in auto complete field automatically added by jazzmin, but not explicitly mentionned as auto-compete in admin.py. This patch automatically define all M2M as autocomplete

![auto_complete](https://user-images.githubusercontent.com/11556772/150098845-0f046721-0eac-4eb1-a71e-61f95780ba23.png)
before on the left, after on the right